### PR TITLE
feat: now OpenAI Responses API is used instead of AI SDK

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,6 @@
     "": {
       "name": "mcp-app-demo",
       "dependencies": {
-        "@ai-sdk/openai": "^1.3.22",
         "@radix-ui/react-alert-dialog": "^1.1.14",
         "@radix-ui/react-dialog": "^1.0.5",
         "@radix-ui/react-dropdown-menu": "^2.0.6",
@@ -53,22 +52,6 @@
         "vite": "^6.1.0",
         "vitest": "^3.0.5",
         "web-vitals": "^4.2.4"
-      }
-    },
-    "node_modules/@ai-sdk/openai": {
-      "version": "1.3.22",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-1.3.22.tgz",
-      "integrity": "sha512-QwA+2EkG0QyjVR+7h6FE7iOu2ivNqAVMm9UJZkVxxTk5OIq5fFJDTEI/zICEMuHImTTXR2JjsL6EirJ28Jc4cw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider": "1.1.3",
-        "@ai-sdk/provider-utils": "2.2.8"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.0.0"
       }
     },
     "node_modules/@ai-sdk/provider": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "check": "prettier --write . && eslint --fix"
   },
   "dependencies": {
-    "@ai-sdk/openai": "^1.3.22",
     "@radix-ui/react-alert-dialog": "^1.1.14",
     "@radix-ui/react-dialog": "^1.0.5",
     "@radix-ui/react-dropdown-menu": "^2.0.6",

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -5,7 +5,7 @@ import { useChat } from 'ai/react'
 import { generateMessageId } from '../mcp/client'
 import type { Message } from 'ai'
 import { useLocalStorage } from '../hooks/useLocalStorage'
-import { type Servers } from '../routes/api/chat'
+import { type Servers } from '../lib/schemas'
 
 export function Chat() {
   const messagesEndRef = useRef<HTMLDivElement>(null)

--- a/src/lib/streaming.ts
+++ b/src/lib/streaming.ts
@@ -1,0 +1,59 @@
+export function streamText(
+  answer: AsyncIterable<any>,
+  onMessageId?: (messageId: string) => void,
+): Response {
+  const encoder = new TextEncoder()
+  const messageId = `msg-${Math.random().toString(36).slice(2)}`
+
+  const stream = new ReadableStream({
+    async start(controller) {
+      // Send initial message ID
+      controller.enqueue(
+        encoder.encode(
+          `f:${JSON.stringify({
+            messageId,
+          })}\n`,
+        ),
+      )
+
+      if (onMessageId) {
+        onMessageId(messageId)
+      }
+
+      let buffer = ''
+
+      const flush = () => {
+        if (buffer) {
+          controller.enqueue(encoder.encode(`0:${JSON.stringify(buffer)}\n`))
+          buffer = ''
+        }
+      }
+
+      for await (const chunk of answer) {
+        if (
+          chunk.type === 'response.output_text.delta' &&
+          typeof chunk.delta === 'string'
+        ) {
+          buffer += chunk.delta
+
+          // Flush on sentence boundaries or when buffer gets large
+          if (buffer.length > 40 || /[.!?\n]$/.test(chunk.delta)) {
+            flush()
+          }
+        }
+      }
+
+      // Flush any remaining content
+      flush()
+      controller.close()
+    },
+  })
+
+  return new Response(stream, {
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      Connection: 'keep-alive',
+    },
+  })
+}

--- a/src/routes/api/chat.ts
+++ b/src/routes/api/chat.ts
@@ -1,8 +1,8 @@
 import { createAPIFileRoute } from '@tanstack/react-start/api'
-import { experimental_createMCPClient, streamText } from 'ai'
-import { openai } from '@ai-sdk/openai'
 import { chatRequestSchema } from '../../lib/schemas'
-import type { Server } from '../../lib/schemas'
+import OpenAI from 'openai'
+import type { Tool } from 'openai/resources/responses/responses.mjs'
+import { streamText } from '../../lib/streaming'
 
 export const APIRoute = createAPIFileRoute('/api/chat')({
   POST: async ({ request }) => {
@@ -22,47 +22,42 @@ export const APIRoute = createAPIFileRoute('/api/chat')({
 
       const { messages, servers } = result.data
 
-      const mcpClients = await Promise.all(
-        Object.values(servers).map(async (server: Server) => {
-          if (server.status !== 'connected') return null
+      if (messages.length === 0) {
+        return new Response(JSON.stringify({ error: 'No messages provided' }), {
+          status: 400,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      }
 
-          return await experimental_createMCPClient({
-            transport: {
-              type: 'sse',
-              url: server.url,
-              headers: {
-                Authorization: `Bearer ${bearerToken}`,
-              },
-            },
-          })
-        }),
-      )
+      const tools = Object.entries(servers)
+        .filter(([_, server]) => server.status === 'connected')
+        .map(([_id, server]) => ({
+          type: 'mcp',
+          server_label: server.name,
+          server_url: server.url,
+          require_approval: 'never',
+          // headers: {
+          //   Authorization: `Bearer ${bearerToken}`,
+          // }
+        })) satisfies Tool[]
 
-      // Filter out null clients and combine their tools
-      const validClients = mcpClients.filter(
-        (client): client is NonNullable<typeof client> => client !== null,
-      )
-      const allTools = validClients.reduce((acc, client) => {
-        if (client.tools) {
-          return { ...acc, ...client.tools }
-        }
-        return acc
-      }, {})
+      // Format the conversation history into a single input string
+      const input = messages
+        .map(
+          (msg) =>
+            `${msg.role === 'user' ? 'User' : 'Assistant'}: ${msg.content}`,
+        )
+        .join('\n\n')
 
-      const response = await streamText({
-        model: openai('gpt-4'),
-        messages,
-        tools: allTools,
-        onError: async (event) => {
-          console.error('Streaming error:', event.error)
-          await Promise.all(validClients.map((client) => client.close()))
-        },
-        onFinish: async () => {
-          await Promise.all(validClients.map((client) => client.close()))
-        },
+      const client = new OpenAI()
+      const answer = await client.responses.create({
+        model: 'gpt-4.1',
+        tools,
+        input,
+        stream: true,
       })
 
-      return response.toDataStreamResponse()
+      return streamText(answer)
     } catch (error) {
       console.error('Error in chat route:', error)
       return new Response(JSON.stringify({ error: 'Internal server error' }), {


### PR DESCRIPTION
Now the OpenAI Responses API is used directly instead of the AI SDK. The reason being is AI SDK currently requires you to create an MCP client for each MCP server you want to get tools for.

The OpenAI Responses API doesn't require multiple MCP clients and just takes the array of tools.

There is the headers sent after error still @wasaga, but I will look into that after.

Also closes #4
