### PR TITLE
fix: now reasoning output is rendered in the UI

### DIFF
--- a/src/components/ChatMessage.tsx
+++ b/src/components/ChatMessage.tsx
@@ -2,7 +2,7 @@ import { cn } from '../lib/utils'
 import type { Message } from '../mcp/client'
 import { formatTimestamp } from '../lib/utils'
 import { Bot, User, CheckCircle2, Clock, AlertCircle } from 'lucide-react'
-import ReactMarkdown from 'react-markdown'
+import { MarkdownContent } from './MarkdownContent'
 
 type ChatMessageProps = {
   message: Message
@@ -49,35 +49,7 @@ export function ChatMessage({ message, isLoading }: ChatMessageProps) {
           )}
         >
           <div className="prose prose-sm dark:prose-invert max-w-none break-words break-all whitespace-pre-wrap">
-            <ReactMarkdown
-              components={{
-                pre: ({ node, ...props }) => (
-                  <pre
-                    className="overflow-x-auto whitespace-pre-wrap break-words break-all"
-                    {...props}
-                  />
-                ),
-                code: ({ node, ...props }) => (
-                  <code
-                    className="break-words break-all whitespace-pre-wrap"
-                    {...props}
-                  />
-                ),
-                a: ({ href, children, ...props }) => (
-                  <a
-                    href={href}
-                    className="break-words break-all"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    {...props}
-                  >
-                    {children}
-                  </a>
-                ),
-              }}
-            >
-              {message.content}
-            </ReactMarkdown>
+            <MarkdownContent content={message.content} />
           </div>
         </div>
 

--- a/src/components/MarkdownContent.tsx
+++ b/src/components/MarkdownContent.tsx
@@ -1,0 +1,41 @@
+import ReactMarkdown from 'react-markdown'
+
+type MarkdownContentProps = {
+  content: string
+}
+
+export function MarkdownContent({ content }: MarkdownContentProps) {
+  return (
+    <div className="prose prose-sm dark:prose-invert max-w-none break-words break-all whitespace-pre-wrap">
+      <ReactMarkdown
+        components={{
+          pre: ({ node, ...props }) => (
+            <pre
+              className="overflow-x-auto whitespace-pre-wrap break-words break-all"
+              {...props}
+            />
+          ),
+          code: ({ node, ...props }) => (
+            <code
+              className="break-words break-all whitespace-pre-wrap"
+              {...props}
+            />
+          ),
+          a: ({ href, children, ...props }) => (
+            <a
+              href={href}
+              className="break-words break-all"
+              target="_blank"
+              rel="noopener noreferrer"
+              {...props}
+            >
+              {children}
+            </a>
+          ),
+        }}
+      >
+        {content}
+      </ReactMarkdown>
+    </div>
+  )
+}

--- a/src/components/ReasoningMessage.tsx
+++ b/src/components/ReasoningMessage.tsx
@@ -1,0 +1,58 @@
+import { Brain } from 'lucide-react'
+import { cn } from '../lib/utils'
+import { MarkdownContent } from './MarkdownContent'
+
+type ReasoningMessageProps = {
+  effort: string
+  summary: string | null
+  model?: string
+  serviceTier?: string
+  temperature?: number
+  topP?: number
+  isLoading?: boolean
+}
+
+export function ReasoningMessage({
+  effort,
+  summary,
+  model,
+  serviceTier,
+  temperature,
+  topP,
+  isLoading,
+}: ReasoningMessageProps) {
+  return (
+    <div className="flex w-full max-w-full gap-2 py-2 animate-in fade-in justify-start">
+      <div
+        className={cn(
+          'flex h-8 w-8 shrink-0 select-none items-center justify-center rounded-md bg-purple-100 text-purple-600 dark:bg-purple-900 dark:text-purple-300',
+          isLoading && 'animate-[pulse_1.5s_ease-in-out_infinite] opacity-80',
+        )}
+      >
+        <Brain className="h-5 w-5" />
+      </div>
+
+      <div className="flex flex-col space-y-1 items-start w-full sm:w-[85%] md:w-[75%] lg:w-[65%]">
+        <div className="rounded-2xl px-4 py-2 text-sm w-full bg-purple-50 text-purple-900 dark:bg-purple-950 dark:text-purple-100">
+          <div className="font-medium mb-1">Reasoning</div>
+          <div className="text-xs space-y-1">
+            {effort && <div>Effort: {effort}</div>}
+            {summary && (
+              <div className="prose prose-sm dark:prose-invert max-w-none break-words break-all whitespace-pre-wrap">
+                <MarkdownContent content={summary} />
+              </div>
+            )}
+            {model && <div>Model: {model}</div>}
+            {serviceTier && <div>Service Tier: {serviceTier}</div>}
+            <div className="flex gap-4">
+              {temperature !== undefined && (
+                <div>Temperature: {temperature}</div>
+              )}
+              {topP !== undefined && <div>Top P: {topP}</div>}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/routes/api/chat.ts
+++ b/src/routes/api/chat.ts
@@ -88,6 +88,13 @@ export const ServerRoute = createServerFileRoute('/api/chat').methods({
         input,
         stream: true,
         user: userId,
+        ...(model.startsWith('o3') || model.startsWith('o4')
+          ? {
+              reasoning: {
+                summary: 'detailed',
+              },
+            }
+          : {}),
       })
 
       return streamText(answer)


### PR DESCRIPTION
Now reasoning output is rendered in the UI. Currently all the chunks for a reasoning summary get flushed at the same time. We can probably stream those in.

Closes #16

**Before**

![CleanShot 2025-07-02 at 15 14 22](https://github.com/user-attachments/assets/09c5cb2a-90b4-4ec8-8ebc-45973cee9769)

**After**

![CleanShot 2025-07-02 at 15 13 33](https://github.com/user-attachments/assets/177370bd-379d-463a-91f5-51b4e19bec57)