### PR TITLE
feat: include UID in requests per OpenAI guidance

### DIFF
--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -52,8 +52,9 @@ export function Chat() {
           .filter(([_, server]) => server),
       ),
       model: selectedModel,
+      userId: user?.id,
     }),
-    [selectedServers, servers, selectedModel],
+    [selectedServers, servers, selectedModel, user?.id],
   )
 
   const { messages, input, handleInputChange, handleSubmit, isLoading } =

--- a/src/contexts/UserContext.tsx
+++ b/src/contexts/UserContext.tsx
@@ -2,7 +2,11 @@ import { createContext, useContext } from 'react'
 import type { ReactNode } from 'react'
 import { getBrowserUser } from '@pomerium/js-sdk'
 import { useQuery } from '@tanstack/react-query'
-import type { UserInfo } from 'node_modules/@pomerium/js-sdk/lib/esm/types/utils'
+import type { UserInfo as PomeriumUserInfo } from 'node_modules/@pomerium/js-sdk/lib/esm/types/utils'
+
+type UserInfo = PomeriumUserInfo & {
+  id: string | undefined
+}
 
 type UserContextType = {
   user: UserInfo | undefined
@@ -16,9 +20,10 @@ async function fetchUserInfo(): Promise<UserInfo> {
   const userInfo = await getBrowserUser()
 
   return {
-    email: userInfo.email ?? '',
-    name: userInfo.name ?? '',
+    email: userInfo.email,
+    name: userInfo.name,
     picture: userInfo.picture as string,
+    id: userInfo.user,
   }
 }
 

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -65,6 +65,7 @@ export const chatRequestSchema = z.object({
   messages: z.array(messageSchema),
   servers: serversSchema,
   model: z.string(),
+  userId: z.string(),
 })
 
 // Types

--- a/src/routes/api/chat.ts
+++ b/src/routes/api/chat.ts
@@ -35,7 +35,7 @@ export const ServerRoute = createServerFileRoute('/api/chat').methods({
         })
       }
 
-      const { messages, servers, model } = result.data
+      const { messages, servers, model, userId } = result.data
 
       if (messages.length === 0) {
         return new Response(JSON.stringify({ error: 'No messages provided' }), {
@@ -87,6 +87,7 @@ export const ServerRoute = createServerFileRoute('/api/chat').methods({
         tools,
         input,
         stream: true,
+        user: userId,
       })
 
       return streamText(answer)


### PR DESCRIPTION
This PR adds support for including a unique end-user ID (uid) in outbound requests to OpenAI, in line with [their abuse monitoring recommendations](https://platform.openai.com/docs/guides/safety-best-practices#end-user-ids). OpenAI recommends sending a unique end-user ID with each request to help them detect and prevent abuse more effectively. This allows them to provide more actionable feedback if any policy violations are identified in our application.

Closes #46