### PR TITLE
fix: scrollbar no longer on message container

### DIFF
--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -376,7 +376,7 @@ export function Chat() {
   }
 
   return (
-    <div className="flex flex-col h-full relative">
+    <div className="flex flex-col min-h-full relative">
       <div className="sticky top-0 z-10 bg-background border-b px-4 py-2 flex justify-between items-center">
         <Button
           variant="outline"
@@ -388,7 +388,7 @@ export function Chat() {
         </Button>
         <ModelSelect value={selectedModel} onValueChange={setSelectedModel} />
       </div>
-      <div className="flex-1 overflow-y-auto">
+      <div className="flex-1">
         <div className="p-4 space-y-4">
           <div className="space-y-4">
             {renderEvents.map((event, idx) => {


### PR DESCRIPTION
This pull request makes two minor adjustments to the layout of the `Chat` component in `src/components/Chat.tsx` to improve its responsiveness and scrolling behavior.

Layout improvements:

* Changed the outer container's height property from `h-full` to `min-h-full` to ensure the component adapts better to varying screen sizes. (`[src/components/Chat.tsxL379-R379](diffhunk://#diff-530ed7d3bba918ebbd3f6970d4142bb0ac62c065099c6ca141d42a434a493029L379-R379)`)
* Removed the `overflow-y-auto` class from the inner container to simplify scrolling behavior. (`[src/components/Chat.tsxL391-R391](diffhunk://#diff-530ed7d3bba918ebbd3f6970d4142bb0ac62c065099c6ca141d42a434a493029L391-R391)`)

**Before**

![CleanShot 2025-07-02 at 16 57 19](https://github.com/user-attachments/assets/7a0dc1ed-a676-4bf3-a109-17ca56d35b84)

**After**

![CleanShot 2025-07-02 at 16 52 13](https://github.com/user-attachments/assets/9cca23fa-4591-4dec-adbc-b7bef7c07363)

Closes #74