### PR TITLE
fix: reason messages match height of avatar when closed now

### DIFF
--- a/src/components/ReasoningMessage.tsx
+++ b/src/components/ReasoningMessage.tsx
@@ -28,14 +28,59 @@ export function ReasoningMessage({
           'flex h-8 w-8 shrink-0 select-none items-center justify-center rounded-md bg-purple-100 text-purple-600 dark:bg-purple-900 dark:text-purple-300',
           isLoading && 'animate-[pulse_1.5s_ease-in-out_infinite] opacity-80',
         )}
+        aria-hidden="true"
       >
         <Brain className="h-5 w-5" />
       </div>
 
       <div className="flex flex-col space-y-1 items-start w-full sm:w-[85%] md:w-[75%] lg:w-[65%]">
-        <div className="rounded-2xl px-4 py-2 text-sm w-full bg-purple-50 text-purple-900 dark:bg-purple-950 dark:text-purple-100">
-          <div className="font-medium mb-1">Reasoning</div>
-          <div className="text-xs space-y-1">
+        <details
+          open
+          className="rounded-2xl px-4 py-2 text-sm w-full bg-purple-50 text-purple-900 dark:bg-purple-950 dark:text-purple-100 group [&:not([open])]:h-8 [&:not([open])]:flex [&:not([open])]:items-center [&:not([open])]:py-0"
+        >
+          <summary className="font-medium mb-1 flex items-center gap-2 list-none [&::-webkit-details-marker]:hidden cursor-pointer group-[&:not([open])]:mb-0">
+            {/* Chevron icon for expand/collapse */}
+            <svg
+              className="h-4 w-4 transition-transform group-open:rotate-90 text-purple-600 dark:text-purple-300"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M9 5l7 7-7 7"
+              />
+            </svg>
+            Reasoning
+            {isLoading && (
+              <span className="ml-2 animate-spin">
+                <svg
+                  className="h-4 w-4"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  aria-label="Loading"
+                >
+                  <circle
+                    className="opacity-25"
+                    cx="12"
+                    cy="12"
+                    r="10"
+                    stroke="currentColor"
+                    strokeWidth="4"
+                  />
+                  <path
+                    className="opacity-75"
+                    fill="currentColor"
+                    d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
+                  />
+                </svg>
+              </span>
+            )}
+          </summary>
+          <div className="text-xs space-y-1 mt-1">
             {effort && <div>Effort: {effort}</div>}
             {summary && (
               <div className="prose prose-sm dark:prose-invert max-w-none break-words break-all whitespace-pre-wrap">
@@ -51,7 +96,7 @@ export function ReasoningMessage({
               {topP !== undefined && <div>Top P: {topP}</div>}
             </div>
           </div>
-        </div>
+        </details>
       </div>
     </div>
   )


### PR DESCRIPTION
This pull request refines the `ReasoningMessage` component in `src/components/ReasoningMessage.tsx` to improve accessibility and user experience. The most significant changes include adding an expand/collapse functionality for the reasoning section and enhancing accessibility with semantic HTML attributes.

### Accessibility improvements:
* Added `aria-hidden="true"` to the decorative `Brain` icon to ensure it is ignored by assistive technologies.

### Expand/collapse functionality:
* Replaced the static `div` container for the reasoning section with a `details` element, enabling expand/collapse functionality. This includes a `summary` element with a chevron icon for toggling, and a spinner icon indicating loading state when applicable. [[1]](diffhunk://#diff-aed8a183b341a54614b7acd5fb9149a8dd759993c81d214078b441e14cc8cf07R31-R83) [[2]](diffhunk://#diff-aed8a183b341a54614b7acd5fb9149a8dd759993c81d214078b441e14cc8cf07L54-R99)

**Before**

![CleanShot 2025-07-03 at 15 18 22@2x](https://github.com/user-attachments/assets/d2285872-ae18-4cc6-8bb6-db9ab40374ce)

**After**

![CleanShot 2025-07-03 at 15 18 54@2x](https://github.com/user-attachments/assets/dc366d04-4816-427b-904d-0877409d36fa)

The reasoning message summaries are open by default, but just wanted to show the height correction.

Closes #85 