### PR TITLE
feat: MCP servers open in a drawer on mobile now

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@radix-ui/react-dialog": "^1.0.5",
         "@radix-ui/react-dropdown-menu": "^2.0.6",
         "@radix-ui/react-label": "^2.0.2",
+        "@radix-ui/react-popover": "^1.1.14",
         "@radix-ui/react-slot": "^1.2.3",
         "@radix-ui/react-switch": "^1.2.5",
         "@radix-ui/react-toast": "^1.1.5",
@@ -1851,6 +1852,43 @@
         "@radix-ui/react-roving-focus": "1.1.10",
         "@radix-ui/react-slot": "1.2.3",
         "@radix-ui/react-use-callback-ref": "1.1.1",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.1.14.tgz",
+      "integrity": "sha512-ODz16+1iIbGUfFEfKx2HTPKizg2MN39uIOV8MXeHnmdd3i/N9Wt7vU46wbHsqA0xoaQyXVcs0KIlBdOA2Y95bw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.10",
+        "@radix-ui/react-focus-guards": "1.1.2",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.7",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
         "aria-hidden": "^1.2.4",
         "react-remove-scroll": "^2.6.3"
       },

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@radix-ui/react-dialog": "^1.0.5",
     "@radix-ui/react-dropdown-menu": "^2.0.6",
     "@radix-ui/react-label": "^2.0.2",
+    "@radix-ui/react-popover": "^1.1.14",
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-switch": "^1.2.5",
     "@radix-ui/react-toast": "^1.1.5",
@@ -71,9 +72,9 @@
   },
   "optionalDependencies": {
     "@rollup/rollup-linux-arm64-gnu": "^4.41.1",
-    "lightningcss-linux-x64-gnu": "^1.30.1",
-    "lightningcss-linux-arm64-gnu": "^1.30.1",
     "lightningcss-darwin-arm64": "^1.30.1",
-    "lightningcss-darwin-x64": "^1.30.1"
+    "lightningcss-darwin-x64": "^1.30.1",
+    "lightningcss-linux-arm64-gnu": "^1.30.1",
+    "lightningcss-linux-x64-gnu": "^1.30.1"
   }
 }

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -724,13 +724,15 @@ export function Chat() {
             </Button>
           </div>
         )}
-        <ServerSelector
-          servers={servers}
-          onServersChange={setServers}
-          selectedServers={selectedServers}
-          onServerToggle={handleServerToggle}
-          disabled={hasStartedChat}
-        />
+        <div className="md:border-t border-gray-200 dark:border-gray-800 bg-background p-2 md:p-4">
+          <ServerSelector
+            servers={servers}
+            onServersChange={setServers}
+            selectedServers={selectedServers}
+            onServerToggle={handleServerToggle}
+            disabled={hasStartedChat}
+          />
+        </div>
         <ChatInput
           onSendMessage={handleSendMessage}
           disabled={isLoading || streaming}

--- a/src/components/ServerSelector.tsx
+++ b/src/components/ServerSelector.tsx
@@ -1,11 +1,25 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useId } from 'react'
 import { Button } from './ui/button'
-import { RefreshCw, Check } from 'lucide-react'
+import { RefreshCw, Check, Settings, Info, Wrench } from 'lucide-react'
+import {
+  Drawer,
+  DrawerClose,
+  DrawerContent,
+  DrawerHeader,
+  DrawerTitle,
+  DrawerTrigger,
+} from './ui/drawer'
+import { Popover, PopoverContent, PopoverTrigger } from './ui/popover'
+import { useMediaQuery } from '../hooks/useMediaQuery'
 import {
   pomeriumRoutesResponseSchema,
   type Server,
   type Servers,
 } from '../lib/schemas'
+
+// Constants
+const POMERIUM_ROUTES_ENDPOINT = '/.pomerium/mcp/routes'
+const POMERIUM_CONNECT_PATH = '/.pomerium/mcp/connect'
 
 type ServerSelectorProps = {
   servers: Servers
@@ -13,23 +27,263 @@ type ServerSelectorProps = {
   selectedServers: string[]
   onServerToggle: (serverId: string) => void
   disabled?: boolean
+  children?: React.ReactNode
 }
 
 const StatusIndicator = ({ status }: { status: Server['status'] }) => {
   const getStatusColor = () => {
     switch (status) {
       case 'connected':
-        return 'bg-green-500'
+        return 'bg-green-600'
       case 'connecting':
-        return 'bg-orange-500'
+        return 'bg-orange-600'
       case 'error':
-        return 'bg-red-500'
+        return 'bg-red-600'
       default:
-        return 'bg-gray-400'
+        return 'bg-gray-500'
     }
   }
 
-  return <div className={`w-2 h-2 rounded-full ${getStatusColor()}`} />
+  const getStatusText = () => {
+    switch (status) {
+      case 'connected':
+        return 'Connected'
+      case 'connecting':
+        return 'Connecting'
+      case 'error':
+        return 'Error'
+      default:
+        return 'Disconnected'
+    }
+  }
+
+  return (
+    <div
+      className="flex items-center gap-1"
+      role="img"
+      aria-label={getStatusText()}
+    >
+      <div
+        className={`w-2 h-2 rounded-full ${getStatusColor()}`}
+        aria-hidden="true"
+      />
+    </div>
+  )
+}
+
+// Extracted header component to reduce complexity
+type ServerSelectorHeaderProps = {
+  isLoading: boolean
+  disabled: boolean
+  onRefresh: () => void
+  showHelp?: boolean
+}
+
+function ServerSelectorHeader({
+  isLoading,
+  disabled,
+  onRefresh,
+  showHelp = false,
+}: ServerSelectorHeaderProps) {
+  return (
+    <div className="flex items-center justify-between min-h-[24px]">
+      <div className="flex items-center gap-2">
+        <span
+          id="server-list-label"
+          className="text-sm font-medium text-gray-700 dark:text-gray-300"
+        >
+          Available Servers
+        </span>
+
+        {showHelp ? (
+          <Popover>
+            <PopoverTrigger asChild>
+              <button
+                className="inline-flex items-center justify-center group"
+                aria-label="Show help for server selection"
+              >
+                <Info className="h-3 w-3 cursor-help text-gray-700 dark:text-gray-300 group-hover:text-gray-900 dark:group-hover:text-gray-100" />
+              </button>
+            </PopoverTrigger>
+            <PopoverContent
+              className="w-80 text-sm"
+              side="bottom"
+              align="start"
+              sideOffset={4}
+            >
+              <p>
+                {disabled
+                  ? 'Server selection is locked after first message'
+                  : 'Click connected servers to toggle selection, disconnected servers to connect'}
+              </p>
+            </PopoverContent>
+          </Popover>
+        ) : (
+          <div className="h-3 w-3" aria-hidden="true" />
+        )}
+
+        {disabled && (
+          <span
+            className="text-xs text-gray-500 dark:text-gray-400"
+            aria-hidden="true"
+          >
+            (Selection locked after first message)
+          </span>
+        )}
+      </div>
+
+      <Button
+        onClick={onRefresh}
+        disabled={isLoading || disabled}
+        variant="ghost"
+        size="sm"
+        className="h-6 w-6 p-0"
+        aria-label={isLoading ? 'Refreshing servers...' : 'Refresh servers'}
+      >
+        <RefreshCw className={`h-3 w-3 ${isLoading ? 'animate-spin' : ''}`} />
+      </Button>
+    </div>
+  )
+}
+
+// Shared component for server selection UI
+const ServerSelectionContent = ({
+  servers,
+  onServersChange,
+  selectedServers,
+  onServerToggle,
+  disabled = false,
+  isLoading,
+  onRefresh,
+  children,
+}: ServerSelectorProps & {
+  isLoading: boolean
+  onRefresh: () => void
+}) => {
+  const connectToServer = async (serverId: string) => {
+    const server = servers[serverId]
+    if (!server) return
+
+    // Use Pomerium MCP connection flow
+    const currentUrl = window.location.href
+    const connectUrl = `${server.url}${POMERIUM_CONNECT_PATH}?redirect_url=${encodeURIComponent(currentUrl)}`
+
+    // Redirect to the connection URL - this will handle the OAuth flow
+    window.location.href = connectUrl
+  }
+
+  const handleServerClick = (serverId: string) => {
+    const server = servers[serverId]
+    if (!server) return
+
+    if (server.status === 'connected') {
+      onServerToggle(serverId)
+    } else {
+      connectToServer(serverId)
+    }
+  }
+
+  const serverList = Object.values(servers).sort((a, b) =>
+    a.url.localeCompare(b.url),
+  )
+
+  if (serverList.length === 0 && !isLoading) {
+    return (
+      <div className="space-y-4">
+        <ServerSelectorHeader
+          isLoading={isLoading}
+          disabled={disabled}
+          onRefresh={onRefresh}
+        />
+        <div
+          role="status"
+          aria-live="polite"
+          className="text-sm text-gray-500 dark:text-gray-400 text-center py-4"
+        >
+          No MCP servers are currently configured in this Pomerium cluster.
+        </div>
+        {children}
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      <ServerSelectorHeader
+        isLoading={isLoading}
+        disabled={disabled}
+        onRefresh={onRefresh}
+        showHelp={!disabled}
+      />
+
+      {isLoading && (
+        <div
+          role="status"
+          aria-live="polite"
+          className="text-sm text-gray-500 dark:text-gray-400"
+        >
+          Loading servers...
+        </div>
+      )}
+
+      <ul
+        className="flex flex-wrap gap-2 list-none p-0 m-0"
+        role="group"
+        aria-labelledby="server-list-label"
+      >
+        {serverList.map((server) => {
+          const isSelected = selectedServers.includes(server.id)
+          const isConnected = server.status === 'connected'
+
+          const buttonAriaLabel = isConnected
+            ? `${server.name} - ${server.status}${isSelected ? ', selected' : ', click to ' + (isSelected ? 'deselect' : 'select')}`
+            : `${server.name} - ${server.status}, click to connect`
+
+          return (
+            <li key={server.id}>
+              <Button
+                onClick={() => handleServerClick(server.id)}
+                disabled={disabled}
+                variant={isSelected ? 'default' : 'outline'}
+                size="sm"
+                className={`
+                  flex items-center gap-2 text-xs transition-all
+                  ${isSelected ? 'bg-indigo-600 hover:bg-indigo-700' : ''}
+                  ${!isConnected ? 'opacity-70' : ''}
+                  ${disabled ? 'cursor-not-allowed' : 'cursor-pointer'}
+                `}
+                aria-label={buttonAriaLabel}
+                aria-pressed={isConnected ? isSelected : undefined}
+              >
+                <div className="flex items-center gap-1.5">
+                  {server.logo_url && (
+                    <img
+                      src={server.logo_url}
+                      alt=""
+                      title={server.name}
+                      className="w-3 h-3 rounded"
+                    />
+                  )}
+                  <StatusIndicator status={server.status} />
+                  <span>{server.name}</span>
+                  {isSelected && (
+                    <Check className="w-3 h-3" aria-hidden="true" />
+                  )}
+                  {!isConnected && !disabled && (
+                    <span className="text-xs opacity-70" aria-hidden="true">
+                      (Click to connect)
+                    </span>
+                  )}
+                </div>
+              </Button>
+            </li>
+          )
+        })}
+      </ul>
+
+      {children}
+    </div>
+  )
 }
 
 export function ServerSelector({
@@ -38,14 +292,18 @@ export function ServerSelector({
   selectedServers,
   onServerToggle,
   disabled = false,
+  children,
 }: ServerSelectorProps) {
   const [isLoading, setIsLoading] = useState(false)
+  const [isDrawerOpen, setIsDrawerOpen] = useState(false)
+  const isMobile = useMediaQuery('(max-width: 768px)')
+  const descriptionId = useId()
 
   // Fetch servers from Pomerium MCP endpoint
   const fetchPomeriumServers = async () => {
     setIsLoading(true)
     try {
-      const response = await fetch('/.pomerium/mcp/routes')
+      const response = await fetch(POMERIUM_ROUTES_ENDPOINT)
       if (!response.ok) {
         throw new Error(`Failed to fetch servers: ${response.status}`)
       }
@@ -89,135 +347,79 @@ export function ServerSelector({
     fetchPomeriumServers()
   }, [])
 
-  const connectToServer = async (serverId: string) => {
-    const server = servers[serverId]
-    if (!server) return
-
-    // Use Pomerium MCP connection flow
-    const currentUrl = window.location.href
-    const connectUrl = `${server.url}/.pomerium/mcp/connect?redirect_url=${encodeURIComponent(currentUrl)}`
-
-    // Redirect to the connection URL - this will handle the OAuth flow
-    window.location.href = connectUrl
+  const sharedProps = {
+    servers,
+    onServersChange,
+    selectedServers,
+    onServerToggle,
+    disabled,
+    isLoading,
+    onRefresh: fetchPomeriumServers,
+    children,
   }
 
-  const handleServerClick = (serverId: string) => {
-    const server = servers[serverId]
-    if (!server) return
+  // On mobile, show drawer trigger with selected server count
+  if (isMobile) {
+    const selectedCount = selectedServers.length
+    const totalServers = Object.keys(servers).length
+    const description = `Opens server selection. ${selectedCount} of ${totalServers} servers selected${disabled ? '. Selection is locked after first message.' : ''}`
 
-    if (server.status === 'connected') {
-      onServerToggle(serverId)
-    } else {
-      connectToServer(serverId)
-    }
-  }
-
-  const serverList = Object.values(servers).sort((a, b) =>
-    a.url.localeCompare(b.url),
-  )
-
-  if (serverList.length === 0 && !isLoading) {
     return (
-      <div className="border-t border-gray-200 dark:border-gray-800 bg-background p-4">
-        <div className="flex items-center justify-between mb-3">
-          <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
-            Available Servers
-          </span>
-          <Button
-            onClick={fetchPomeriumServers}
-            disabled={isLoading}
-            variant="ghost"
-            size="sm"
-            className="h-6 w-6 p-0"
-          >
-            <RefreshCw
-              className={`h-3 w-3 ${isLoading ? 'animate-spin' : ''}`}
-            />
-          </Button>
-        </div>
-        <div className="text-sm text-gray-500 dark:text-gray-400 text-center py-4">
-          No MCP servers are currently configured in this Pomerium cluster.
-        </div>
+      <div className="space-y-4">
+        <Drawer open={isDrawerOpen} onOpenChange={setIsDrawerOpen}>
+          <DrawerTrigger asChild>
+            <Button
+              variant="outline"
+              className="flex items-center justify-between"
+              disabled={disabled}
+              aria-describedby={descriptionId}
+            >
+              <div className="flex items-center gap-2">
+                <Wrench className="w-4 h-4" aria-hidden="true" />
+                <span className="text-sm">
+                  MCP Servers ({selectedCount}/{totalServers})
+                </span>
+              </div>
+              {disabled && (
+                <span
+                  className="text-xs text-gray-500 dark:text-gray-400"
+                  aria-hidden="true"
+                >
+                  Locked
+                </span>
+              )}
+            </Button>
+          </DrawerTrigger>
+          <div id={descriptionId} className="sr-only">
+            {description}
+          </div>
+          <DrawerContent>
+            <DrawerHeader>
+              <DrawerTitle className="text-left">
+                MCP Server Selection
+              </DrawerTitle>
+            </DrawerHeader>
+            <div
+              className="max-h-[60vh] overflow-y-auto p-4"
+              role="region"
+              aria-label="Server selection content"
+            >
+              <ServerSelectionContent {...sharedProps} />
+            </div>
+            <div className="p-4 border-t">
+              <DrawerClose asChild>
+                <Button variant="outline" className="w-full">
+                  Close
+                </Button>
+              </DrawerClose>
+            </div>
+          </DrawerContent>
+        </Drawer>
+        {children}
       </div>
     )
   }
 
-  return (
-    <div className="border-t border-gray-200 dark:border-gray-800 bg-background p-4">
-      <div className="flex items-center justify-between mb-3">
-        <div className="flex items-center gap-2">
-          <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
-            Available Servers
-          </span>
-          {disabled && (
-            <span className="text-xs text-gray-500 dark:text-gray-400">
-              (Selection locked after first message)
-            </span>
-          )}
-        </div>
-        <Button
-          onClick={fetchPomeriumServers}
-          disabled={isLoading || disabled}
-          variant="ghost"
-          size="sm"
-          className="h-6 w-6 p-0"
-        >
-          <RefreshCw className={`h-3 w-3 ${isLoading ? 'animate-spin' : ''}`} />
-        </Button>
-      </div>
-
-      <div className="flex flex-wrap gap-2">
-        {isLoading && (
-          <div className="text-sm text-gray-500 dark:text-gray-400">
-            Loading servers...
-          </div>
-        )}
-
-        {serverList.map((server) => {
-          const isSelected = selectedServers.includes(server.id)
-          const isConnected = server.status === 'connected'
-
-          return (
-            <Button
-              key={server.id}
-              onClick={() => handleServerClick(server.id)}
-              disabled={disabled}
-              variant={isSelected ? 'default' : 'outline'}
-              size="sm"
-              className={`
-                flex items-center gap-2 text-xs transition-all
-                ${isSelected ? 'bg-indigo-600 hover:bg-indigo-700' : ''}
-                ${!isConnected ? 'opacity-70' : ''}
-                ${disabled ? 'cursor-not-allowed' : 'cursor-pointer'}
-              `}
-            >
-              <div className="flex items-center gap-1.5">
-                {server.logo_url && (
-                  <img
-                    src={server.logo_url}
-                    alt={`${server.name} logo`}
-                    className="w-3 h-3 rounded"
-                  />
-                )}
-                <StatusIndicator status={server.status} />
-                <span>{server.name}</span>
-                {isSelected && <Check className="w-3 h-3" />}
-                {!isConnected && !disabled && (
-                  <span className="text-xs opacity-70">(Click to connect)</span>
-                )}
-              </div>
-            </Button>
-          )
-        })}
-      </div>
-
-      {serverList.length > 0 && (
-        <p className="text-xs text-gray-500 dark:text-gray-400 mt-2">
-          {disabled
-            ? 'Server selection is locked for this conversation'
-            : 'Click connected servers to toggle selection, disconnected servers to connect'}
-        </p>
-      )}
-    </div>
-  )
+  // On desktop, show inline server selection (current behavior)
+  return <ServerSelectionContent {...sharedProps} />
 }

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -1,0 +1,46 @@
+import * as React from "react"
+import * as PopoverPrimitive from "@radix-ui/react-popover"
+
+import { cn } from "@/lib/utils"
+
+function Popover({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Root>) {
+  return <PopoverPrimitive.Root data-slot="popover" {...props} />
+}
+
+function PopoverTrigger({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
+  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />
+}
+
+function PopoverContent({
+  className,
+  align = "center",
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Content>) {
+  return (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Content
+        data-slot="popover-content"
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden",
+          className
+        )}
+        {...props}
+      />
+    </PopoverPrimitive.Portal>
+  )
+}
+
+function PopoverAnchor({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Anchor>) {
+  return <PopoverPrimitive.Anchor data-slot="popover-anchor" {...props} />
+}
+
+export { Popover, PopoverTrigger, PopoverContent, PopoverAnchor }


### PR DESCRIPTION
Now MCP servers are loaded in a drawer component on smaller screens.

Closes #84

![CleanShot 2025-07-08 at 09 04 29](https://github.com/user-attachments/assets/55115fd8-3e2b-4c71-b606-e3902223e0a8)

This pull request introduces several updates to the codebase, including adding a new dependency for popovers, implementing a reusable popover component, and enhancing the `Chat` component with a new server selector UI. The changes improve functionality and maintainability by centralizing popover logic and refining the user interface.

### Dependency Updates:
* Added `@radix-ui/react-popover` to the `package.json` dependencies to enable popover functionality.

### Component Enhancements:
* Implemented a reusable popover component in `src/components/ui/popover.tsx`, including `Popover`, `PopoverTrigger`, `PopoverContent`, and `PopoverAnchor` components. These components use Radix UI primitives and provide consistent styling and behavior for popovers.

### UI Improvements:
* Updated the `Chat` component in `src/components/Chat.tsx` to include a server selector wrapped in a styled container, enhancing the user interface for server management.

### Optional Dependency Adjustments:
* Reorganized the `optionalDependencies` section in `package.json` to ensure consistent formatting and inclusion of the latest versions of `lightningcss` for various platforms.