### PR TITLE
feat: add timeout error handling in Chat

### DIFF
--- a/src/components/BotError.stories.tsx
+++ b/src/components/BotError.stories.tsx
@@ -1,0 +1,43 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { BotError } from './BotError'
+import { AlertTriangle } from 'lucide-react'
+
+const meta: Meta<typeof BotError> = {
+  title: 'Bot/BotError',
+  component: BotError,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'BotError displays an error message from the bot, using accessible Shadcn/ui and Tailwind styling. Use for error boundaries or bot error responses.',
+      },
+    },
+  },
+}
+
+export default meta
+
+type Story = StoryObj<typeof BotError>
+
+export const Default: Story = {
+  args: {
+    message: 'Something went wrong. Please try again.',
+  },
+}
+
+export const LongError: Story = {
+  args: {
+    message: (
+      <>
+        <div>
+          <strong>Request failed:</strong> The server returned a 500 error.
+          <br />
+          Please check your network connection or try again later.
+          <br />
+          <code>Error: Internal Server Error</code>
+        </div>
+      </>
+    ),
+  },
+}

--- a/src/components/BotError.test.tsx
+++ b/src/components/BotError.test.tsx
@@ -1,0 +1,38 @@
+// @vitest-environment jsdom
+import {
+  getByRole,
+  getByTestId,
+  getByText,
+  render,
+} from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { BotError } from './BotError'
+
+describe('BotError', () => {
+  it('renders a simple error message', () => {
+    const { container } = render(
+      <BotError message="Something went wrong. Please try again." />,
+    )
+
+    expect(getByText(container, 'Error')).toBeInTheDocument()
+    expect(
+      getByText(container, 'Something went wrong. Please try again.'),
+    ).toBeInTheDocument()
+  })
+
+  it('renders a long error message with HTML', () => {
+    const longMessage = (
+      <div data-testid="error-message">
+        <strong>Request failed:</strong> The server returned a 500 error.
+        <br />
+        Please check your network connection or try again later.
+        <br />
+        <code>Error: Internal Server Error</code>
+      </div>
+    )
+    const { container } = render(<BotError message={longMessage} />)
+
+    expect(getByText(container, 'Error')).toBeInTheDocument()
+    expect(getByTestId(container, 'error-message')).toBeInTheDocument()
+  })
+})

--- a/src/components/BotError.tsx
+++ b/src/components/BotError.tsx
@@ -1,9 +1,10 @@
 import { AlertTriangle } from 'lucide-react'
 import { CollapsibleSection } from './ui/collapsible-section'
 import { MessageAvatar } from './MessageAvatar'
+import type { ReactNode } from 'react'
 
 interface BotErrorProps {
-  message: string
+  message: ReactNode
 }
 
 export function BotError({ message }: BotErrorProps) {
@@ -15,7 +16,7 @@ export function BotError({ message }: BotErrorProps) {
       />
       <div className="flex flex-col space-y-1 items-start w-full sm:w-[85%] md:w-[75%] lg:w-[65%]">
         <CollapsibleSection title="Error" variant="error" open={true}>
-          <div>{message}</div>
+          {message}
         </CollapsibleSection>
       </div>
     </div>

--- a/src/lib/streaming.test.ts
+++ b/src/lib/streaming.test.ts
@@ -1,5 +1,20 @@
 import { describe, it, expect } from 'vitest'
 import { stopStreamProcessing } from './utils/streaming'
+import { streamText } from './streaming'
+
+function iterableFromArray<T>(arr: T[]): AsyncIterable<T> {
+  return {
+    [Symbol.asyncIterator]() {
+      let i = 0
+      return {
+        next: async () =>
+          i < arr.length
+            ? { value: arr[i++], done: false }
+            : { value: undefined, done: true },
+      }
+    },
+  }
+}
 
 describe('stopStreamProcessing', () => {
   it('replaces response body with an empty closed stream', async () => {
@@ -57,5 +72,75 @@ describe('stopStreamProcessing', () => {
 
     // Should still have a body (the empty stream)
     expect(response.body).toBeInstanceOf(ReadableStream)
+  })
+})
+
+describe('streamText', () => {
+  it('emits stream_done when the stream ends', async () => {
+    // Simulate a normal completion (not timing out)
+    const chunks = [
+      { type: 'response.output_text.delta', delta: "I'm glad you asked!" },
+      {
+        type: 'response.output_text.delta',
+        delta: ' Here are a few universally nice things that',
+      },
+      {
+        type: 'response.output_text.delta',
+        delta: ' could have happened today:\n\n',
+      },
+      {
+        type: 'response.output_text.delta',
+        delta: '- Someone smiled at a stranger, brightening',
+      },
+      { type: 'response.output_text.delta', delta: ' their day\n' },
+      {
+        type: 'response.output_text.delta',
+        delta: '- A teacher helped a student understand a',
+      },
+      { type: 'response.output_text.delta', delta: ' difficult concept\n' },
+      {
+        type: 'response.output_text.delta',
+        delta: '- A kind person paid for someone’s coffee',
+      },
+      { type: 'response.output_text.delta', delta: ' in line\n' },
+      {
+        type: 'response.output_text.delta',
+        delta: '- A pet reunited with its owner at a local',
+      },
+      { type: 'response.output_text.delta', delta: ' animal shelter\n' },
+      {
+        type: 'response.output_text.delta',
+        delta: '- A friend reached out just to say hello\n\n',
+      },
+      {
+        type: 'response.output_text.delta',
+        delta: 'Would you like to hear some real, uplifting',
+      },
+      { type: 'response.output_text.delta', delta: ' news from today?' },
+      { type: 'response.output_text.delta', delta: ' Just let me know!' },
+      {
+        type: 'response.tool_call_completed',
+        response: {
+          /* ...omitted... */
+        },
+      },
+      {
+        type: 'response.completed',
+        response: {
+          /* ...omitted... */
+        },
+      },
+    ]
+    const response = streamText(iterableFromArray(chunks))
+    const reader = response.body!.getReader()
+    let result = ''
+    let done = false
+    while (!done) {
+      const { value, done: d } = await reader.read()
+      if (value) result += new TextDecoder().decode(value)
+      done = d
+    }
+    // Should include t:{...stream_done...}
+    expect(result).toMatch(/t:{\"type\":\"stream_done\"}/)
   })
 })

--- a/src/lib/streaming.ts
+++ b/src/lib/streaming.ts
@@ -357,6 +357,10 @@ export function streamText(
 
         // Flush any remaining content
         flush()
+        // Emit a final done event to signal successful completion
+        controller.enqueue(
+          encoder.encode(`t:${JSON.stringify({ type: 'stream_done' })}\n`),
+        )
         controller.close()
       } catch (error: unknown) {
         console.error('Error during streamed response:', error)


### PR DESCRIPTION
Now if a request times out, the user receives an error message indicating that it might be Pomerium timing out the request.

Note that I set my timeout for the route to five seconds so I could see it error out which is why the error appears that quickly in the GIF.

## Testing
Set your chat app route to a low timeout, e.g. 5 seconds like I did. Use a tool like the web search tool. See it timeout after 5 seconds and render the error message.


Closes #127

![CleanShot 2025-07-11 at 08 15 56](https://github.com/user-attachments/assets/f8e533e3-208b-41ad-bfae-577039edcfea)