### PR TITLE
fix: timeout error no longer appears after tool call fail or new chat

### DIFF
--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -905,6 +905,7 @@ export function Chat() {
     setHasStartedChat(false)
     setStreamBuffer([])
     setStreaming(false)
+    setTimedOut(false)
     setMessages([]) // Clear messages completely - initialMessage will be shown via renderEvents logic
     setInput('')
     setFocusTimestamp(Date.now())


### PR DESCRIPTION
This pull request introduces enhancements to the chat functionality and streaming logic to improve error handling and streamline event signaling. The most important changes include adding a reset for the `timedOut` state in the chat component, centralizing the `stream_done` event chunk, and ensuring the `stream_done` event is emitted even when errors occur during streaming.

Relates to #127

<img width="3692" height="1560" alt="CleanShot 2025-07-11 at 10 23 10@2x" src="https://github.com/user-attachments/assets/f81d438f-3e5e-4c30-979e-7b8d83852fb7" />