### PR TITLE
fix: server & tools selected count takes tools into account now

### DIFF
--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -921,6 +921,35 @@ export function Chat() {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
   }, [])
 
+  const toolToggles = [
+    {
+      key: 'codeInterpreter',
+      isActive: useCodeInterpreter,
+      component: (
+        <CodeInterpreterToggle
+          key="codeInterpreter"
+          useCodeInterpreter={useCodeInterpreter}
+          onToggle={setUseCodeInterpreter}
+          selectedModel={selectedModel}
+          disabled={hasStartedChat}
+        />
+      ),
+    },
+    {
+      key: 'webSearch',
+      isActive: useWebSearch,
+      component: (
+        <WebSearchToggle
+          key="webSearch"
+          useWebSearch={useWebSearch}
+          onToggle={setUseWebSearch}
+          selectedModel={selectedModel}
+          disabled={hasStartedChat}
+        />
+      ),
+    },
+  ]
+
   return (
     <div className="flex flex-col min-h-full relative">
       <div className="sticky top-0 z-10 bg-background border-b px-4 py-2 flex justify-between items-center">
@@ -1148,20 +1177,8 @@ export function Chat() {
               selectedServers={selectedServers}
               onServerToggle={handleServerToggle}
               disabled={hasStartedChat}
-            >
-              <CodeInterpreterToggle
-                useCodeInterpreter={useCodeInterpreter}
-                onToggle={setUseCodeInterpreter}
-                selectedModel={selectedModel}
-                disabled={hasStartedChat}
-              />
-              <WebSearchToggle
-                useWebSearch={useWebSearch}
-                onToggle={setUseWebSearch}
-                selectedModel={selectedModel}
-                disabled={hasStartedChat}
-              />
-            </ServerSelector>
+              toolToggles={toolToggles}
+            />
           </div>
         )}
         <ChatInput

--- a/src/test/utils/mocks.ts
+++ b/src/test/utils/mocks.ts
@@ -1,0 +1,33 @@
+/**
+ * Mocks window.matchMedia to simulate a mobile device (matches: true).
+ * Call this at the start of a test to enable mobile view logic.
+ */
+export function mockMobile() {
+  window.matchMedia = vi.fn().mockImplementation((q) => ({
+    matches: true,
+    media: q,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }))
+}
+
+/**
+ * Mocks window.matchMedia to simulate a desktop/large screen device (matches: false).
+ * Call this at the start of a test to enable desktop view logic.
+ */
+export function mockDesktop() {
+  window.matchMedia = vi.fn().mockImplementation((q) => ({
+    matches: false,
+    media: q,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }))
+}


### PR DESCRIPTION
Now the tools selected appear in the total count for selected servers and selected tools.

**Before**

![CleanShot 2025-07-11 at 18 28 12](https://github.com/user-attachments/assets/8fe5706d-fff8-4959-8220-eb17591c2f8d)

**After**

![CleanShot 2025-07-11 at 18 26 54](https://github.com/user-attachments/assets/d1f3a6b3-6b98-4fd1-8add-c24fe03e6c8e)