### PR TITLE
fix /.pomerium/mcp/connect call when base url has path prefix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "packages": {
     "": {
       "name": "mcp-app-demo",
-      "license": "Apache-2.0",
       "dependencies": {
         "@pomerium/js-sdk": "^1.1.0",
         "@radix-ui/react-alert-dialog": "^1.1.14",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "packages": {
     "": {
       "name": "mcp-app-demo",
+      "license": "Apache-2.0",
       "dependencies": {
         "@pomerium/js-sdk": "^1.1.0",
         "@radix-ui/react-alert-dialog": "^1.1.14",

--- a/src/components/ServerSelector.tsx
+++ b/src/components/ServerSelector.tsx
@@ -135,11 +135,9 @@ const ServerSelectionContent = ({
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     if (!server) return
     const currentUrl = window.location.href
-    // Extract base URL from server URL (protocol + host)
-    const serverUrl = new URL(server.url)
-    const baseUrl = `${serverUrl.protocol}//${serverUrl.host}`
-    const connectUrl = `${baseUrl}${POMERIUM_CONNECT_PATH}?redirect_url=${encodeURIComponent(currentUrl)}`
-    window.location.href = connectUrl
+    const connectUrl = new URL(POMERIUM_CONNECT_PATH, server.url)
+    connectUrl.searchParams.set('redirect_url', currentUrl)
+    window.location.href = connectUrl.toString()
   }
 
   const disconnectMutation = useDisconnectServer(servers, onServersChange)

--- a/src/components/ServerSelector.tsx
+++ b/src/components/ServerSelector.tsx
@@ -135,7 +135,10 @@ const ServerSelectionContent = ({
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     if (!server) return
     const currentUrl = window.location.href
-    const connectUrl = `${server.url}${POMERIUM_CONNECT_PATH}?redirect_url=${encodeURIComponent(currentUrl)}`
+    // Extract base URL from server URL (protocol + host)
+    const serverUrl = new URL(server.url)
+    const baseUrl = `${serverUrl.protocol}//${serverUrl.host}`
+    const connectUrl = `${baseUrl}${POMERIUM_CONNECT_PATH}?redirect_url=${encodeURIComponent(currentUrl)}`
     window.location.href = connectUrl
   }
 


### PR DESCRIPTION
We support specifying MCP server path prefix since https://github.com/pomerium/pomerium/pull/5726, so that the URLs might not be necessarily at `/`. 

This PR fixes to always use URL base path when appending `/.pomerium/mcp/connect` to it. 

Fix: https://linear.app/pomerium/issue/ENG-2620/mcp-connect-500-instead-of-sending-to-oauth-screen


